### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+dist: trusty
+sudo: false
+go:
+- 1.8.3
+- 1.9
+- tip
+
+script:
+- git clone -b dev https://github.com/Bytom/bytom.git $GOPATH/src/github.com/bytom
+- cd $GOPATH/src/github.com/bytom
+- make install
+- make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Bytom
 =====
-
+[![Build Status](https://travis-ci.org/Bytom/bytom.png)](https://travis-ci.org/Bytom/bytom)
 [![AGPL v3](https://img.shields.io/badge/license-AGPL%20v3-brightgreen.svg)](./LICENSE)
 
 ## Table of Contents


### PR DESCRIPTION
Currently, the path of bytom is not standard, so we have to enter the right directory manually in travis. It can be improved later.