### PR TITLE
Remove old inessential logger injection

### DIFF
--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -479,7 +479,6 @@ FOR_LOOP:
 				break FOR_LOOP
 			}
 			if msgBytes != nil {
-				c.Logger.Debug("Received bytes", "chID", pkt.ChannelID, "msgBytes", msgBytes)
 				log.WithFields(log.Fields{
 					"channelID": pkt.ChannelID,
 					"msgBytes":  msgBytes,


### PR DESCRIPTION
Remove `log.Logger` in function arguments.