### PR TITLE
build: pass the right linker flags as version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,10 @@ _cgo_export.*
 _testmain.go
 
 cmd/bytomd/bytomd
+cmd/bytomd/.bytomd
 cmd/bytomcli/bytomcli
 cmd/bytom/.bytom
+.bytomd
 
 *.exe
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,17 @@ PACKAGES = $(shell go list ./... | grep -v '/vendor/' | grep -v '/rpc/')
 
 all: install test
 
+bytomd:
+	@echo "Building bytomd to cmd/bytomd/bytomd"
+	@go build -ldflags "-X github.com/bytom/version.GitCommit=`git rev-parse HEAD`" \
+    -o cmd/bytomd/bytomd cmd/bytomd/main.go
+
+bytomcli:
+	@echo "Building bytomcli to cmd/bytomcli/bytomcli"
+	@go build -ldflags "-X github.com/bytom/version.GitCommit=`git rev-parse HEAD`" \
+    -o cmd/bytomcli/bytomcli cmd/bytomcli/main.go
+
 install: get_vendor_deps
-	@go install --ldflags '-extldflags "-static"' \
-		--ldflags "-X github.com/Bytom/blockchain/version.GitCommit=`git rev-parse HEAD`" ./node/
 	@echo "====> Done!"
 
 get_vendor_deps: ensure_tools

--- a/README.md
+++ b/README.md
@@ -64,15 +64,14 @@ $ git clone https://github.com/Bytom/bytom $GOPATH/src/github.com/bytom
 ``` bash
 $ cd $GOPATH/src/github.com/bytom
 $ make install
-$ cd ./cmd/bytomd
-$ go build
+$ make bytomd
 ```
 
 - Bytomcli
 
 ```go
 $ cd $GOPATH/src/github.com/bytom/cmd/bytomcli
-$ go build
+$ make bytomcli
 ```
 
 ## Example

--- a/version/version.go
+++ b/version/version.go
@@ -6,9 +6,7 @@ const Fix = "2"
 
 var (
 	// The full version string
-	Version = "0.1.2"
-
-	// GitCommit is set with --ldflags "-X main.gitCommit=$(git rev-parse HEAD)"
+	Version   = "0.1.2"
 	GitCommit string
 )
 


### PR DESCRIPTION
Hello.
This PR is just workaround to pass the right linker flags to linker and It's not full support the `bytomd` and `bytomcli` because of different usage of version between `bytomd` and `bytomcli`