### PR TITLE
Don't init native asset in init function

### DIFF
--- a/blockchain/asset/asset.go
+++ b/blockchain/asset/asset.go
@@ -35,7 +35,7 @@ const (
 	indexPrefix         = "ASSIDX:"
 )
 
-func InitNativeAsset() {
+func initNativeAsset() {
 	genesisBlock := cfg.GenerateGenesisBlock()
 	signer := &signers.Signer{Type: "internal"}
 	alias := consensus.BTMAlias
@@ -85,6 +85,7 @@ var (
 
 //NewRegistry create new registry
 func NewRegistry(db dbm.DB, chain *protocol.Chain) *Registry {
+	initNativeAsset()
 	return &Registry{
 		db:               db,
 		chain:            chain,

--- a/blockchain/asset/asset.go
+++ b/blockchain/asset/asset.go
@@ -23,10 +23,6 @@ import (
 	"github.com/bytom/protocol/vm/vmutil"
 )
 
-func init() {
-	DefaultNativeAsset = generateNativeAsset()
-}
-
 var DefaultNativeAsset *Asset
 
 const (
@@ -36,24 +32,24 @@ const (
 	AliasPrefix = "ALS:"
 	//ExternalAssetPrefix is external definition assets prefix
 	ExternalAssetPrefix = "EXA"
-	indexPrefix   = "ASSIDX:"
+	indexPrefix         = "ASSIDX:"
 )
 
-func generateNativeAsset() *Asset {
+func InitNativeAsset() {
 	genesisBlock := cfg.GenerateGenesisBlock()
 	signer := &signers.Signer{Type: "internal"}
 	alias := consensus.BTMAlias
 
 	definitionBytes, _ := serializeAssetDef(consensus.BTMDefinitionMap)
-
-	return &Asset{
+	DefaultNativeAsset = &Asset{
 		Signer:            signer,
 		AssetID:           *consensus.BTMAssetID,
 		Alias:             &alias,
 		VMVersion:         1,
 		DefinitionMap:     consensus.BTMDefinitionMap,
 		RawDefinitionByte: definitionBytes,
-		InitialBlockHash:  genesisBlock.Hash()}
+		InitialBlockHash:  genesisBlock.Hash(),
+	}
 }
 
 func AliasKey(name string) []byte {

--- a/node/node.go
+++ b/node/node.go
@@ -190,7 +190,6 @@ func NewNode(config *cfg.Config) *Node {
 	if !config.Wallet.Disable {
 		walletDB := dbm.NewDB("wallet", config.DBBackend, config.DBDir())
 		accounts = account.NewManager(walletDB, chain)
-		asset.InitNativeAsset()
 		assets = asset.NewRegistry(walletDB, chain)
 		wallet, err = w.NewWallet(walletDB, accounts, assets, chain)
 		if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -190,8 +190,8 @@ func NewNode(config *cfg.Config) *Node {
 	if !config.Wallet.Disable {
 		walletDB := dbm.NewDB("wallet", config.DBBackend, config.DBDir())
 		accounts = account.NewManager(walletDB, chain)
-		assets = asset.NewRegistry(walletDB, chain)
 		asset.InitNativeAsset()
+		assets = asset.NewRegistry(walletDB, chain)
 		wallet, err = w.NewWallet(walletDB, accounts, assets, chain)
 		if err != nil {
 			log.WithField("error", err).Error("init NewWallet")

--- a/node/node.go
+++ b/node/node.go
@@ -191,6 +191,7 @@ func NewNode(config *cfg.Config) *Node {
 		walletDB := dbm.NewDB("wallet", config.DBBackend, config.DBDir())
 		accounts = account.NewManager(walletDB, chain)
 		assets = asset.NewRegistry(walletDB, chain)
+		asset.InitNativeAsset()
 		wallet, err = w.NewWallet(walletDB, accounts, assets, chain)
 		if err != nil {
 			log.WithField("error", err).Error("init NewWallet")


### PR DESCRIPTION
Previously, the init of logrus is after the invoke of creating native
asset, which may lead to incomplete logging.