### PR TITLE
fix asset alias for upper

### DIFF
--- a/api/request.go
+++ b/api/request.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"strings"
 
 	"github.com/bytom/consensus"
 	"github.com/bytom/encoding/json"
@@ -26,6 +27,7 @@ func (a *API) filterAliases(ctx context.Context, br *BuildRequest) error {
 	for i, m := range br.Actions {
 		id, _ := m["asset_id"].(string)
 		alias, _ := m["asset_alias"].(string)
+		alias = strings.ToUpper(alias)
 		if id == "" && alias != "" {
 			switch alias {
 			case consensus.BTMAlias:


### PR DESCRIPTION
Asset aliases are capital letters when they are created, so they are converted to uppercase when the transaction is created