### PR TITLE
[外部测试] use built-in string operator replace strings.Compare for better readability and performance

### DIFF
--- a/accesstoken/accesstoken.go
+++ b/accesstoken/accesstoken.go
@@ -107,7 +107,7 @@ func (cs *CredentialStore) Check(ctx context.Context, id string, secret string) 
 		return err
 	}
 
-	if strings.Compare(strings.Split(token.Token, ":")[1], secret) == 0 {
+	if strings.Split(token.Token, ":")[1] == secret {
 		return nil
 	}
 

--- a/accesstoken/accesstoken_test.go
+++ b/accesstoken/accesstoken_test.go
@@ -56,7 +56,7 @@ func TestList(t *testing.T) {
 		t.Error("List errored: get invalid length")
 	}
 	for _, v := range got {
-		if m := strings.Compare(v.Token, tokenMap[v.ID].Token); m != 0 {
+		if v.Token != tokenMap[v.ID].Token {
 			t.Errorf("List error: ID: %s, expected token: %s, DB token: %s", v.ID, *tokenMap[v.ID], v.Token)
 		}
 		continue

--- a/api/accounts.go
+++ b/api/accounts.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"context"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 
 	"github.com/bytom/account"
@@ -105,7 +103,7 @@ func (a *API) listAddresses(ctx context.Context, ins struct {
 
 	var addresses []*addressResp
 	for _, cp := range cps {
-		if cp.Address == "" || (len(accountID) != 0 && strings.Compare(accountID, cp.AccountID) != 0) {
+		if cp.Address == "" || (accountID != "" && accountID != cp.AccountID) {
 			continue
 		}
 

--- a/blockchain/txfeed/txfeed.go
+++ b/blockchain/txfeed/txfeed.go
@@ -282,10 +282,10 @@ func (t *Tracker) Delete(ctx context.Context, alias string) error {
 func outputFilter(txfeed *TxFeed, value *query.AnnotatedOutput) bool {
 	assetidstr := value.AssetID.String()
 
-	if 0 != strings.Compare(txfeed.Param.assetID, assetidstr) && txfeed.Param.assetID != "" {
+	if txfeed.Param.assetID != assetidstr && txfeed.Param.assetID != "" {
 		return false
 	}
-	if 0 != strings.Compare(txfeed.Param.transType, value.Type) && txfeed.Param.transType != "" {
+	if txfeed.Param.transType != value.Type && txfeed.Param.transType != "" {
 		return false
 	}
 	if txfeed.Param.amountLowerLimit > value.Amount && txfeed.Param.amountLowerLimit != 0 {

--- a/netsync/block_keeper.go
+++ b/netsync/block_keeper.go
@@ -1,7 +1,6 @@
 package netsync
 
 import (
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -107,7 +106,7 @@ func (bk *blockKeeper) BlockRequestWorker(peerID string, maxPeerHeight uint64) e
 	}
 	bestHash := bk.chain.BestBlockHash()
 	log.Info("Block sync complete. height:", bk.chain.BestBlockHeight(), " hash:", bestHash)
-	if strings.Compare(currentHash.String(), bestHash.String()) != 0 {
+	if currentHash.String() != bestHash.String() {
 		log.Info("Broadcast new chain status.")
 
 		block, err := bk.chain.GetBlockByHash(bestHash)
@@ -141,7 +140,7 @@ func (bk *blockKeeper) BlockRequest(peerID string, height uint64) (*types.Block,
 		select {
 		case pendingResponse := <-bk.pendingProcessCh:
 			block = pendingResponse.block
-			if strings.Compare(pendingResponse.peerID, peerID) != 0 {
+			if pendingResponse.peerID != peerID {
 				log.Warning("From different peer")
 				continue
 			}
@@ -158,7 +157,7 @@ func (bk *blockKeeper) BlockRequest(peerID string, height uint64) (*types.Block,
 			log.Warning("Request block timeout")
 			return nil, errGetBlockTimeout
 		case peerid := <-bk.quitReqBlockCh:
-			if strings.Compare(*peerid, peerID) == 0 {
+			if *peerid == peerID {
 				log.Info("Quite block request worker")
 				return nil, errPeerDropped
 			}

--- a/netsync/fetcher.go
+++ b/netsync/fetcher.go
@@ -6,8 +6,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
 
-	"strings"
-
 	"github.com/bytom/p2p"
 	core "github.com/bytom/protocol"
 	"github.com/bytom/protocol/bc"
@@ -100,7 +98,7 @@ func (f *Fetcher) loop() {
 				f.forgetBlock(hash)
 				continue
 			}
-			if strings.Compare(op.block.PreviousBlockHash.String(), f.chain.BestBlockHash().String()) != 0 {
+			if op.block.PreviousBlockHash.String() != f.chain.BestBlockHash().String() {
 				f.forgetBlock(hash)
 				continue
 			}

--- a/netsync/protocol_reactor.go
+++ b/netsync/protocol_reactor.go
@@ -2,7 +2,6 @@ package netsync
 
 import (
 	"reflect"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -117,7 +116,7 @@ func (pr *ProtocolReactor) AddPeer(peer *p2p.Peer) error {
 	for {
 		select {
 		case status := <-pr.peerStatusCh:
-			if strings.Compare(status.peerID, peer.Key) == 0 {
+			if status.peerID == peer.Key {
 				pr.peers.AddPeer(peer)
 				pr.peers.SetPeerStatus(status.peerID, status.height, status.hash)
 				pr.syncTransactions(pr.peers.Peer(peer.Key))

--- a/p2p/pex_reactor.go
+++ b/p2p/pex_reactor.go
@@ -6,8 +6,6 @@ import (
 	"math/rand"
 	"reflect"
 	"time"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	wire "github.com/tendermint/go-wire"
 	cmn "github.com/tendermint/tmlibs/common"
@@ -268,7 +266,7 @@ func (r *PEXReactor) ensurePeers() {
 			alreadyDialing := r.Switch.IsDialing(try)
 			var alreadyConnected bool
 			for _, v := range r.Switch.Peers().list {
-				if strings.Compare(v.mconn.RemoteAddress.String(), try.String()) == 0 {
+				if v.mconn.RemoteAddress.String() == try.String() {
 					alreadyConnected = true
 					break
 				}


### PR DESCRIPTION
I see there are lot of `strings.Compare(..., ...) == 0` usage in the code, and from this function, I see:

```
// Compare returns an integer comparing two strings lexicographically.
// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
//
// Compare is included only for symmetry with package bytes.
// It is usually clearer and always faster to use the built-in
// string comparison operators ==, <, >, and so on.
func Compare(a, b string) int {
	// NOTE(rsc): This function does NOT call the runtime cmpstring function,
	// because we do not want to provide any performance justification for
	// using strings.Compare. Basically no one should use strings.Compare.
	// As the comment above says, it is here only for symmetry with package bytes.
	// If performance is important, the compiler should be changed to recognize
	// the pattern so that all code doing three-way comparisons, not just code
	// using strings.Compare, can benefit.
	if a == b {
		return 0
	}
	if a < b {
		return -1
	}
	return +1
}
```

So I think it's probably a better choice not to use it
