### PR TITLE
Fix p2p switch unit test

### DIFF
--- a/p2p/listener_test.go
+++ b/p2p/listener_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestListener(t *testing.T) {
 	// Create a listener
-	l := NewDefaultListener("tcp", ":8001", true, log.TestingLogger())
+	l, _ := NewDefaultListener("tcp", ":8001", true, log.TestingLogger())
 
 	// Dial the listener
 	lAddr := l.ExternalAddress()

--- a/p2p/pex_reactor_test.go
+++ b/p2p/pex_reactor_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/tendermint/tmlibs/log"
 )
 
+var (
+	sw *Switch
+)
+
 func TestPEXReactorBasic(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
@@ -25,7 +29,7 @@ func TestPEXReactorBasic(t *testing.T) {
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
-	r := NewPEXReactor(book)
+	r := NewPEXReactor(book, sw)
 	r.SetLogger(log.TestingLogger())
 
 	assert.NotNil(r)
@@ -41,7 +45,7 @@ func TestPEXReactorAddRemovePeer(t *testing.T) {
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
-	r := NewPEXReactor(book)
+	r := NewPEXReactor(book, sw)
 	r.SetLogger(log.TestingLogger())
 
 	size := book.Size()
@@ -79,7 +83,7 @@ func TestPEXReactorRunning(t *testing.T) {
 		switches[i] = makeSwitch(config, i, "127.0.0.1", "123.123.123", func(i int, sw *Switch) *Switch {
 			sw.SetLogger(log.TestingLogger().With("switch", i))
 
-			r := NewPEXReactor(book)
+			r := NewPEXReactor(book, sw)
 			r.SetLogger(log.TestingLogger())
 			r.SetEnsurePeersPeriod(250 * time.Millisecond)
 			sw.AddReactor("pex", r)
@@ -91,7 +95,8 @@ func TestPEXReactorRunning(t *testing.T) {
 	for _, s := range switches {
 		addr, _ := NewNetAddressString(s.NodeInfo().ListenAddr)
 		book.AddAddress(addr, addr)
-		s.AddListener(NewDefaultListener("tcp", s.NodeInfo().ListenAddr, true, log.TestingLogger()))
+		l, _ := NewDefaultListener("tcp", s.NodeInfo().ListenAddr, true, log.TestingLogger())
+		s.AddListener(l)
 	}
 
 	// start switches
@@ -125,7 +130,7 @@ func TestPEXReactorReceive(t *testing.T) {
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
-	r := NewPEXReactor(book)
+	r := NewPEXReactor(book, sw)
 	r.SetLogger(log.TestingLogger())
 
 	peer := createRandomPeer(false)
@@ -150,7 +155,7 @@ func TestPEXReactorAbuseFromPeer(t *testing.T) {
 	book := NewAddrBook(dir+"addrbook.json", true)
 	book.SetLogger(log.TestingLogger())
 
-	r := NewPEXReactor(book)
+	r := NewPEXReactor(book, sw)
 	r.SetLogger(log.TestingLogger())
 	r.SetMaxMsgCountByPeer(5)
 

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -61,10 +61,11 @@ func (tr *TestReactor) GetChannels() []*ChannelDescriptor {
 	return tr.channels
 }
 
-func (tr *TestReactor) AddPeer(peer *Peer) {
+func (tr *TestReactor) AddPeer(peer *Peer) error {
 	tr.mtx.Lock()
 	defer tr.mtx.Unlock()
 	tr.peersAdded = append(tr.peersAdded, peer)
+	return nil
 }
 
 func (tr *TestReactor) RemovePeer(peer *Peer, reason interface{}) {
@@ -102,12 +103,12 @@ func makeSwitchPair(t testing.TB, initSwitch func(int, *Switch) *Switch) (*Switc
 func initSwitchFunc(i int, sw *Switch) *Switch {
 	// Make two reactors of two channels each
 	sw.AddReactor("foo", NewTestReactor([]*ChannelDescriptor{
-		&ChannelDescriptor{ID: byte(0x00), Priority: 10},
-		&ChannelDescriptor{ID: byte(0x01), Priority: 10},
+		{ID: byte(0x00), Priority: 10},
+		{ID: byte(0x01), Priority: 10},
 	}, true))
 	sw.AddReactor("bar", NewTestReactor([]*ChannelDescriptor{
-		&ChannelDescriptor{ID: byte(0x02), Priority: 10},
-		&ChannelDescriptor{ID: byte(0x03), Priority: 10},
+		{ID: byte(0x02), Priority: 10},
+		{ID: byte(0x03), Priority: 10},
 	}, true))
 	return sw
 }
@@ -180,10 +181,12 @@ func TestConnAddrFilter(t *testing.T) {
 
 	// connect to good peer
 	go func() {
-		s1.addPeerWithConnection(c1)
+		err := s1.addPeerWithConnection(c1)
+		assert.NotNil(t, err, "expected err")
 	}()
 	go func() {
-		s2.addPeerWithConnection(c2)
+		err := s2.addPeerWithConnection(c2)
+		assert.NotNil(t, err, "expected err")
 	}()
 
 	// Wait for things to happen, peers to get added...
@@ -215,10 +218,12 @@ func TestConnPubKeyFilter(t *testing.T) {
 
 	// connect to good peer
 	go func() {
-		s1.addPeerWithConnection(c1)
+		err := s1.addPeerWithConnection(c1)
+		assert.NotNil(t, err, "expected err")
 	}()
 	go func() {
-		s2.addPeerWithConnection(c2)
+		err := s2.addPeerWithConnection(c2)
+		assert.NotNil(t, err, "expected err")
 	}()
 
 	// Wait for things to happen, peers to get added...
@@ -294,12 +299,12 @@ func BenchmarkSwitches(b *testing.B) {
 	s1, s2 := makeSwitchPair(b, func(i int, sw *Switch) *Switch {
 		// Make bar reactors of bar channels each
 		sw.AddReactor("foo", NewTestReactor([]*ChannelDescriptor{
-			&ChannelDescriptor{ID: byte(0x00), Priority: 10},
-			&ChannelDescriptor{ID: byte(0x01), Priority: 10},
+			{ID: byte(0x00), Priority: 10},
+			{ID: byte(0x01), Priority: 10},
 		}, false))
 		sw.AddReactor("bar", NewTestReactor([]*ChannelDescriptor{
-			&ChannelDescriptor{ID: byte(0x02), Priority: 10},
-			&ChannelDescriptor{ID: byte(0x03), Priority: 10},
+			{ID: byte(0x02), Priority: 10},
+			{ID: byte(0x03), Priority: 10},
 		}, false))
 		return sw
 	})


### PR DESCRIPTION
1、修复switch_test中的TestReactor实现Reactor接口问题