### PR TITLE
improve log format by adding a comma

### DIFF
--- a/mining/cpuminer/cpuminer.go
+++ b/mining/cpuminer/cpuminer.go
@@ -110,7 +110,7 @@ out:
 				blockHash := block.Hash()
 				m.newBlockCh <- &blockHash
 			} else {
-				log.WithField("height", block.BlockHeader.Height).Errorf("Miner fail on ProcessBlock %v", err)
+				log.WithField("height", block.BlockHeader.Height).Errorf("Miner fail on ProcessBlock, %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
如果没有逗号的话，出现的日志可能是这样的：

```
time="2018-05-17T12:10:14+08:00" level=error msg="Miner fail on ProcessBlock block timestamp is not in the valid range: invalid block" height=32
```

不容易看懂