### PR TITLE
check whether alias is missing or void in create-key (#1257)

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -113,6 +113,7 @@ var respErrFormatter = map[error]httperror.Info{
 	pseudohsm.ErrLoadKey:              {400, "BTM802", "Key not found or wrong password"},
 	pseudohsm.ErrTooManyAliasesToList: {400, "BTM803", "Requested key aliases exceeds limit"},
 	pseudohsm.ErrDecrypt:              {400, "BTM804", "Could not decrypt key with given passphrase"},
+	pseudohsm.ErrMissingOrVoidAlias:   {400, "BTM805", "missing or void alias"},
 }
 
 // Map error values to standard bytom error codes. Missing entries

--- a/blockchain/pseudohsm/pseudohsm.go
+++ b/blockchain/pseudohsm/pseudohsm.go
@@ -20,6 +20,7 @@ var (
 	ErrLoadKey              = errors.New("key not found or wrong password ")
 	ErrTooManyAliasesToList = errors.New("requested aliases exceeds limit")
 	ErrDecrypt              = errors.New("could not decrypt key with given passphrase")
+	ErrMissingOrVoidAlias   = errors.New("missing or void alias")
 )
 
 // HSM type for storing pubkey and privatekey
@@ -53,6 +54,9 @@ func (h *HSM) XCreate(alias string, auth string) (*XPub, error) {
 	defer h.cacheMu.Unlock()
 
 	normalizedAlias := strings.ToLower(strings.TrimSpace(alias))
+	if normalizedAlias == "" {
+		return nil, ErrMissingOrVoidAlias
+	}
 	if ok := h.cache.hasAlias(normalizedAlias); ok {
 		return nil, ErrDuplicateKeyAlias
 	}


### PR DESCRIPTION
The keys with void alias will not show in list-keys method, and when the bytomd starts, there is warning msg like below. 
And the [API ref](https://github.com/Bytom/bytom/wiki/API-Reference#create-key) does not say alias is optional, so I assume alias is needed and made this modification.

```
time="2018-08-26T03:31:42+08:00" level=warning msg="missing or void alias" can't decode key, key path:=/Users/huwenchao/Library/Bytom/keystore/UTC--2018-08-25
T19-18-10.383730000Z--5070a78e-a46e-489a-8bce-107f60671383
```