### PR TITLE
remove redundant code

### DIFF
--- a/account/builder.go
+++ b/account/builder.go
@@ -333,7 +333,6 @@ func UtxoToInputs(signer *signers.Signer, u *UTXO) (*types.TxInput, *txbuilder.S
 
 	case *common.AddressWitnessScriptHash:
 		sigInst.AddRawWitnessKeys(signer.XPubs, path, signer.Quorum)
-		path := signers.Path(signer, signers.AccountKeySpace, u.ControlProgramIndex)
 		derivedXPubs := chainkd.DeriveXPubs(signer.XPubs, path)
 		derivedPKs := chainkd.XPubKeys(derivedXPubs)
 		script, err := vmutil.P2SPMultiSigProgram(derivedPKs, signer.Quorum)

--- a/account/builder.go
+++ b/account/builder.go
@@ -324,16 +324,15 @@ func UtxoToInputs(signer *signers.Signer, u *UTXO) (*types.TxInput, *txbuilder.S
 		return nil, nil, err
 	}
 
+	sigInst.AddRawWitnessKeys(signer.XPubs, path, signer.Quorum)
+	derivedXPubs := chainkd.DeriveXPubs(signer.XPubs, path)
+
 	switch address.(type) {
 	case *common.AddressWitnessPubKeyHash:
-		sigInst.AddRawWitnessKeys(signer.XPubs, path, signer.Quorum)
-		derivedXPubs := chainkd.DeriveXPubs(signer.XPubs, path)
 		derivedPK := derivedXPubs[0].PublicKey()
 		sigInst.WitnessComponents = append(sigInst.WitnessComponents, txbuilder.DataWitness([]byte(derivedPK)))
 
 	case *common.AddressWitnessScriptHash:
-		sigInst.AddRawWitnessKeys(signer.XPubs, path, signer.Quorum)
-		derivedXPubs := chainkd.DeriveXPubs(signer.XPubs, path)
 		derivedPKs := chainkd.XPubKeys(derivedXPubs)
 		script, err := vmutil.P2SPMultiSigProgram(derivedPKs, signer.Quorum)
 		if err != nil {


### PR DESCRIPTION
在account/builder.go文件的UtxoToInputs方法
“path := signers.Path(signer, signers.AccountKeySpace, u.ControlProgramIndex) “一模一样的代码重复定义了两次，建议去掉。